### PR TITLE
Solving the problem with loading BootKernelExtensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -1705,7 +1705,7 @@
 			<key>ScanPolicy</key>
 			<integer>0</integer>
 			<key>SecureBootModel</key>
-			<string>Default</string>
+			<string>Disabled</string>
 			<key>Vault</key>
 			<string>Optional</string>
 		</dict>


### PR DESCRIPTION
Solving the problem with loading Boot Kernel Extensions:
![image](https://user-images.githubusercontent.com/26282232/105644617-73c87b00-5ea7-11eb-8099-920f72da11b9.png)


The solution to the problem can be found here:
- [https://www.codejam.info/2020/11/upgrading-hackintosh-catalina-big-sur-clover-opencore.html](https://www.codejam.info/2020/11/upgrading-hackintosh-catalina-big-sur-clover-opencore.html)
- [https://www.reddit.com/r/hackintosh/comments/j37wbd/upgrading_to_big_sur_beta_9_issues/](https://www.reddit.com/r/hackintosh/comments/j37wbd/upgrading_to_big_sur_beta_9_issues/)